### PR TITLE
added css injection for non-array styles value

### DIFF
--- a/queries/ecma/injections.scm
+++ b/queries/ecma/injections.scm
@@ -29,3 +29,18 @@
                ))
   )
 ))
+
+((decorator
+  (call_expression
+    function: ((identifier) @_name
+               (#eq? @_name "Component"))
+    arguments: (arguments
+                 (object
+                   (pair
+                     key: ((property_identifier) @_prop
+                           (#eq? @_prop "styles"))
+                     value: ((template_string) @css (#offset! @css 0 1 0 -1))
+                   )
+               ))
+  )
+))


### PR DESCRIPTION
added support for css injection when styles is just a template:

![2023-11-25_15-47](https://github.com/nvim-treesitter/nvim-treesitter-angular/assets/13023797/939933d3-ef1f-434d-b743-bcaeeb648f6a)